### PR TITLE
Alter behaviour after password entry

### DIFF
--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -287,7 +287,7 @@ void MainWindow::login() {
 		m_ui->txtPassword->setText("");
 		for (int i = 0; i < password.length(); ++i)
 			password[i] = 0;
-		m_ui->tblSites->setFocus();
+		m_ui->txtFilter->setFocus();
 		if (m_application_settings.show_identicon)
 			m_hide_identicon_timer->start(2000);
 


### PR DESCRIPTION
After entering the password and pressing return, the focus should be set to the filter text field.

This is faster than having to manually click it or press tab an enormous amount of time.