### PR TITLE
user_widget: remove fixed-size

### DIFF
--- a/src/user_widget.cpp
+++ b/src/user_widget.cpp
@@ -26,7 +26,6 @@ UserWidget::UserWidget(Type type, QWidget *parent) :
 	ui(new Ui::UserWidget)
 {
 	ui->setupUi(this);
-	setFixedSize(size());
 	checkInputValidity();
 
 	QFont label_font = ui->txtIdenticon->font();


### PR DESCRIPTION
On some setups it cuts the text of the checkbox.

Fixes https://github.com/bkueng/qMasterPassword/issues/25