### PR TITLE
build: add scrypt-windows as submodule

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -105,7 +105,7 @@ jobs:
 
       # NOTE: execute *AFTER* dependency installation to ensure that it uses a git checkout!
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -16,31 +16,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Check out scrypt
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
-          repository: barrysteyn/scrypt-windows
-          path: scrypt-windows
+          submodules: true
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
-
-      - name: Install node
-        uses: actions/setup-node@master
-
-      - name: Install node-gyp
-        shell: powershell
-        run: |
-          npm install --global node-gyp@latest
-
-      - name: Build scrypt-windows
-        working-directory: scrypt-windows
-        run: |
-          node-gyp configure
-          node-gyp build
-          node-gyp install
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
@@ -52,12 +33,8 @@ jobs:
           setup-python: false
 
       - name: Configure
-        env:
-          CXXFLAGS: -I${{ github.workspace }}/scrypt-windows/scrypt-1.1.6/lib
-        run: >
-          cmake -B ${{ runner.temp }}/build
-          "-DCMAKE_LIBRARY_PATH=${{ github.workspace }}/scrypt-windows/build/Release"
-          .
+        run: |
+          cmake -B ${{ runner.temp }}/build .
 
       - name: Build
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/3rdparty/scrypt/scrypt-windows"]
+	path = src/3rdparty/scrypt/scrypt-windows
+	url = git@github.com:barrysteyn/scrypt-windows.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.18)
 set(TARGET qMasterPassword)
 project(${TARGET}
-   LANGUAGES CXX
+    LANGUAGES C CXX
 )
 
 set(CMAKE_AUTOUIC_SEARCH_PATHS ui)
@@ -83,13 +83,7 @@ if(UNIX)
 endif()
 
 if(WIN32)
-    find_library(SCRYPT_LIBRARY NAMES scrypt scrypt_lib)
-    target_link_options(${TARGET} BEFORE PRIVATE
-        /LTCG /INCREMENTAL:NO
-        /NODEFAULTLIB:libcmt.lib
-    )
     target_link_libraries(${TARGET} PRIVATE
-        ${SCRYPT_LIBRARY}
         ws2_32
     )
 endif()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/bkueng/qMasterPassword.svg)](https://travis-ci.org/bkueng/qMasterPassword)
+[![GitHub Build Status](https://github.com/bkueng/qMasterPassword/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/bkueng/qMasterPassword/actions/workflows/build.yml?query=branch%3Amain+event%3Apush)
+[![Travis CI Build Status](https://travis-ci.org/bkueng/qMasterPassword.svg)](https://travis-ci.org/bkueng/qMasterPassword)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/4067/badge.svg)](https://scan.coverity.com/projects/4067)
 
 ### qMasterPassword

--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ and a site name. This means you automatically get different passwords for each
 account and there is no password file that can be lost or get stolen. There is
 also no need to trust any online password service.
 
-See https://spectre.app/#introduction to get more familiar with the concept
+See [this introduction page](https://spectre.app/#introduction) to get more familiar with the concept
 and reasons why to use it.
 
-The algorithm is described here: 
-https://spectre.app/spectre-algorithm.pdf
+The algorithm is described [here](https://spectre.app/spectre-algorithm.pdf).
 
-https://spectre.app also contains other compatible software for various platforms, like
+The [Spectre home page](https://spectre.app) also contains other compatible software for various platforms, like
 Android or iOS.
 
 qMasterPassword is developed on Linux and also tested on Windows. For Windows

--- a/README.md
+++ b/README.md
@@ -30,10 +30,17 @@ there are prebuilt binaries under
 * Qt 5.2 or higher (see branch qt4.8 for older Qt version support)
 * cmake, make or ninja
 * OpenSSL (libcrypto library)
-* libscrypt library (https://github.com/technion/libscrypt for Linux/OSX,
-  https://github.com/barrysteyn/scrypt-windows for Windows).
+* Linux/OSX: [libscrypt](https://github.com/technion/libscrypt) library
 
-  On Debian/Ubuntu, the library is available as `libscrypt-dev`.
+  On Debian/Ubuntu, it is available as `libscrypt-dev`.
+
+  On RedHat/Fedora, it is available as `libscrypt-devel`.
+
+* Windows: [scrypt-windows](https://github.com/barrysteyn/scrypt-windows) has been added as
+a git submodule.
+
+  You need to add `--recurse-submodules` to the `git clone` command line.
+
 * Linux: libX11 libXtst
 
 

--- a/src/3rdparty/CMakeLists.txt
+++ b/src/3rdparty/CMakeLists.txt
@@ -1,4 +1,6 @@
 if(WIN32)
+    add_subdirectory(scrypt)
+
     target_sources(${TARGET} PRIVATE
         InputBuilder.cpp
         InputSimulator.cpp

--- a/src/3rdparty/scrypt/CMakeLists.txt
+++ b/src/3rdparty/scrypt/CMakeLists.txt
@@ -1,0 +1,33 @@
+set(SCRYPT_WINDOWS_LIB scrypt-windows)
+set(SCRYPT_WINDOWS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/scrypt-windows)
+set(SCRYPT_SOURCE_DIR  ${SCRYPT_WINDOWS_DIR}/scrypt-1.1.6)
+
+# static library implementation
+add_library(${SCRYPT_WINDOWS_LIB} STATIC
+    ${SCRYPT_SOURCE_DIR}/lib/crypto/crypto_scrypt-sse.c
+    ${SCRYPT_SOURCE_DIR}/lib/crypto/sha256.c
+    ${SCRYPT_WINDOWS_DIR}/win/mman.c
+)
+target_compile_definitions(${SCRYPT_WINDOWS_LIB} PRIVATE
+    CONFIG_H_FILE="${SCRYPT_WINDOWS_DIR}/config.h"
+)
+target_include_directories(${SCRYPT_WINDOWS_LIB} PRIVATE
+    ${SCRYPT_SOURCE_DIR}
+    ${SCRYPT_SOURCE_DIR}/lib/crypto
+    ${SCRYPT_SOURCE_DIR}/lib/scryptenc
+    ${SCRYPT_SOURCE_DIR}/lib/util
+    ${SCRYPT_WINDOWS_DIR}/win/include
+)
+# disable Qt features for static library code
+set_target_properties(${SCRYPT_WINDOWS_LIB} PROPERTIES
+    AUTOMOC OFF
+    AUTOUIC OFF
+)
+
+# static library interface
+target_include_directories(${TARGET} PRIVATE
+    ${SCRYPT_SOURCE_DIR}/lib
+)
+target_link_libraries(${TARGET} PRIVATE
+    ${SCRYPT_WINDOWS_LIB}
+)


### PR DESCRIPTION
This is the simple approach: we know that the code from scrypt-windows repository compiles to a working static library on Windows.

- add git repository barrysteyn/scrypt-windows as submodule
- enable submodules checkout feature in Windows workflow
- convert the information from binding.gyp to a CMakeList.txt
- enable language C in project to enable CMake support for C modules
- add new directory src/3rdparty/scrypt to Windows build
- remove imported scrypt static library bits from Windows build
- remove scypt-windows steps from Windows workflow
- update build instructions accordingly
- README: add titles to links
- README: add status badge for GitHub actions
