### PR TITLE
Make fill form shortcuts optional

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{cpp,h}]
+indent_style = tab
+indent_size = 8
+
+[CMakeLists.txt]
+indent_size = 4
+
+[*.{qrc,ts,xml}]
+indent_size = 4
+
+[*.{ui,appdata.xml}]
+indent_size = 1

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -30,6 +30,8 @@ jobs:
           - container: fedora:38
             qt:        6
             appimage:  true
+          - container: fedora:rawhide
+            no_x11:    true
 
       fail-fast: false
 
@@ -40,13 +42,21 @@ jobs:
       DEBIAN_FRONTEND:     noninteractive
       DEBIAN_QT5_PACKAGES: qtbase5-dev qttools5-dev
       DEBIAN_QT6_PACKAGES: qt6-base-dev qt6-tools-dev qt6-tools-dev-tools qt6-l10n-tools libgl1-mesa-dev
+      DEBIAN_X11_PACKAGES: libx11-dev libxkbcommon-x11-dev libxtst-dev
       REDHAT_QT5_PACKAGES: qt5-linguist
       REDHAT_QT6_PACKAGES: qt6-qttools-devel
+      REDHAT_X11_PACKAGES: libX11-devel libXtst-devel libxkbcommon-x11-devel
 
     steps:
       - name: Detect OS release
         run: |
           . /etc/os-release && echo "OS_RELEASE_ID=${ID}" >>${GITHUB_ENV}
+
+      - name: Disable X11 dependencies
+        run: |
+          echo "CONFIGURE_NO_X11=-DDISABLE_FILL_FORM_SHORTCUTS=1" >>${GITHUB_ENV}
+        if: |
+          matrix.no_x11
 
       - name: Add packages for AppImage Build
         run: |
@@ -61,6 +71,12 @@ jobs:
         if: |
           env.OS_RELEASE_ID == 'debian' || env.OS_RELEASE_ID == 'ubuntu'
 
+      - name: Add X11 packages for Debian systems
+        run: |
+          echo "X11_PACKAGES=${DEBIAN_X11_PACKAGES}" >>${GITHUB_ENV}
+        if: |
+          matrix.no_x11 != true && ( env.OS_RELEASE_ID == 'debian' || env.OS_RELEASE_ID == 'ubuntu' )
+
       - name: Install dependencies for Debian systems
         run: >
           apt-get install --no-install-recommends -q -y
@@ -71,10 +87,8 @@ jobs:
           g++
           libscrypt-dev
           libssl-dev
-          libx11-dev
-          libxkbcommon-x11-dev
-          libxtst-dev
           ${DEBIAN_QT${{ matrix.qt }}_PACKAGES}
+          ${X11_PACKAGES}
           ${APPIMAGE_PACKAGES}
         if: |
           env.OS_RELEASE_ID == 'debian' || env.OS_RELEASE_ID == 'ubuntu'
@@ -83,6 +97,12 @@ jobs:
         run: dnf upgrade -y
         if: |
           env.OS_RELEASE_ID == 'fedora'
+
+      - name: Add X11 packages for RedHat systems
+        run: |
+          echo "X11_PACKAGES=${REDHAT_X11_PACKAGES}" >>${GITHUB_ENV}
+        if: |
+          matrix.no_x11 != true && ( env.OS_RELEASE_ID == 'fedora' )
 
       - name: Install dependencies for RedHat systems
         run: >
@@ -93,12 +113,10 @@ jobs:
           ninja-build
           gcc-c++
           libscrypt-devel
-          libX11-devel
-          libXtst-devel
-          libxkbcommon-x11-devel
           openssl-devel
           qt${{ matrix.qt }}-qtbase-devel
           ${REDHAT_QT${{ matrix.qt }}_PACKAGES}
+          ${X11_PACKAGES}
           ${APPIMAGE_PACKAGES}
         if: |
           env.OS_RELEASE_ID == 'fedora'
@@ -110,7 +128,7 @@ jobs:
       - name: Configure
         run: |
           rm -rf ${RUNNER_TEMP}/build
-          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -B ${RUNNER_TEMP}/build .
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release ${CONFIGURE_NO_X11} -B ${RUNNER_TEMP}/build .
 
       - name: Build
         run: cmake --build ${RUNNER_TEMP}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,6 @@ if(WIN32)
             --verbose 2
             \"$ENV{WINDEPLOY_DIR}/bin/${CMAKE_PROJECT_NAME}$<TARGET_FILE_SUFFIX:${TARGET}>\"
     )
-endif()
 
     add_custom_target(makensis
         COMMAND makensis
@@ -113,6 +112,8 @@ endif()
             -wx
             ${CMAKE_CURRENT_SOURCE_DIR}/data/windows/installer.nsi
     )
+endif()
+
 install(
     TARGETS ${TARGET}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,15 @@ else()
     )
 endif()
 
-add_subdirectory(include)
-add_subdirectory(src)
-add_subdirectory(test)
-add_subdirectory(ui)
+option(DISABLE_FILL_FORM_SHORTCUTS "Build without fill form support" OFF)
+if (DISABLE_FILL_FORM_SHORTCUTS)
+    message(STATUS "Fill form shortcuts are disabled")
+    target_compile_definitions(${TARGET} PRIVATE
+        DISABLE_FILL_FORM_SHORTCUTS
+    )
+else()
+    message(STATUS "Fill form shortcuts are enabled")
+endif()
 
 # LINUX requires CMake >= 3.25.0
 if(LINUX OR (UNIX AND NOT APPLE))
@@ -79,13 +84,15 @@ target_include_directories(${TARGET} PRIVATE ${OPENSSL_INCLUDE_DIR})
 
 if(UNIX)
     find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS DBus)
-    find_package(X11 REQUIRED COMPONENTS Xtst xkbcommon_X11)
     target_link_libraries(${TARGET} PRIVATE
         Qt::DBus
-        X11
-        Xtst
         scrypt
     )
+
+    if (NOT DISABLE_FILL_FORM_SHORTCUTS)
+        # this defines X11_FOUND
+        find_package(X11 REQUIRED COMPONENTS Xtst xkbcommon_X11)
+    endif()
 endif()
 
 if(WIN32)
@@ -113,6 +120,12 @@ if(WIN32)
             ${CMAKE_CURRENT_SOURCE_DIR}/data/windows/installer.nsi
     )
 endif()
+
+# subdirectories can rely on variables set by find_package() calls
+add_subdirectory(include)
+add_subdirectory(src)
+add_subdirectory(test)
+add_subdirectory(ui)
 
 install(
     TARGETS ${TARGET}

--- a/data/windows/.gitignore
+++ b/data/windows/.gitignore
@@ -1,3 +1,0 @@
-
-/windows_files
-

--- a/include/main_window.h
+++ b/include/main_window.h
@@ -36,7 +36,9 @@
 #include "app_settings.h"
 #include "import_export.h"
 #include "identicon.h"
+#ifndef DISABLE_FILL_FORM_SHORTCUTS
 #include "keypress.h"
+#endif
 
 namespace Ui {
 class MainWindow;
@@ -69,8 +71,10 @@ public:
 	enum class ShortcutAction {
 		CopyPWToClipboard,
 		CopyUserToClipboard,
+#ifndef DISABLE_FILL_FORM_SHORTCUTS
 		FillForm,
 		FillFormPasswordOnly,
+#endif
 		SelectFilter,
 		PreviousItem,
 		NextItem,
@@ -105,7 +109,9 @@ private:
 	void activateLogoutTimer();
 	void abortLogoutTimer();
 	void openSelectedUrl();
+#ifndef DISABLE_FILL_FORM_SHORTCUTS
 	void fillForm(bool password_only = false);
+#endif
 
 	MasterPassword m_master_password;
 	Identicon m_identicon;
@@ -134,7 +140,9 @@ private:
 
 	int m_copy_column_idx;
 
+#ifndef DISABLE_FILL_FORM_SHORTCUTS
 	Keypress m_keypress;
+#endif
 
 	/** key bindings for actions on selected item. an action can have multiple
 	 *  shortcuts */

--- a/src/3rdparty/CMakeLists.txt
+++ b/src/3rdparty/CMakeLists.txt
@@ -1,11 +1,13 @@
 if(WIN32)
     add_subdirectory(scrypt)
 
-    target_sources(${TARGET} PRIVATE
-        InputBuilder.cpp
-        InputSimulator.cpp
-        KeyboardSimulator.cpp
-        MouseSimulator.cpp
-        WindowsInputDeviceStateAdaptor.cpp
-    )
+    if (NOT DISABLE_FILL_FORM_SHORTCUTS)
+        target_sources(${TARGET} PRIVATE
+            InputBuilder.cpp
+            InputSimulator.cpp
+            KeyboardSimulator.cpp
+            MouseSimulator.cpp
+            WindowsInputDeviceStateAdaptor.cpp
+	)
+    endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,19 +18,25 @@ target_sources(${TARGET} PRIVATE
     user_widget.cpp
 )
 
-# OS specific keypress handling implementation
-if (LINUX OR (UNIX AND NOT APPLE))
-    target_sources(${TARGET} PRIVATE
-        keypress_linux.cpp
-    )
-elseif(WIN32)
-    target_sources(${TARGET} PRIVATE
-        keypress_windows.cpp
-    )
-else()
-    target_sources(${TARGET} PRIVATE
-        keypress.cpp
-    )
+# Keypress insertion implementation for "Fill Form" shortcuts
+if (NOT DISABLE_FILL_FORM_SHORTCUTS)
+    if (X11_FOUND)
+        target_sources(${TARGET} PRIVATE
+            keypress_linux.cpp
+        )
+        target_link_libraries(${TARGET} PRIVATE
+            X11
+            Xtst
+        )
+    elseif(WIN32)
+        target_sources(${TARGET} PRIVATE
+            keypress_windows.cpp
+        )
+    else()
+        target_sources(${TARGET} PRIVATE
+            keypress.cpp
+        )
+    endif()
 endif()
 
 add_subdirectory(3rdparty)

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -105,12 +105,14 @@ MainWindow::MainWindow(QWidget *parent) :
 			QKeySequence(Qt::Key_Y));
 	m_table_shortcuts[(int)ShortcutAction::CopyUserToClipboard].push_back(
 			QKeySequence(Qt::Key_U));
+#ifndef DISABLE_FILL_FORM_SHORTCUTS
 	m_table_shortcuts[(int)ShortcutAction::FillForm].push_back(
 			QKeySequence(QKeySequence::Paste));
 	m_table_shortcuts[(int)ShortcutAction::FillForm].push_back(
 			QKeySequence(Qt::Key_P));
 	m_table_shortcuts[(int)ShortcutAction::FillFormPasswordOnly].push_back(
 			QKeySequence(Qt::SHIFT | Qt::Key_P));
+#endif
 	m_table_shortcuts[(int)ShortcutAction::SelectFilter].push_back(
 			QKeySequence(Qt::Key_Slash));
 	m_table_shortcuts[(int)ShortcutAction::PreviousItem].push_back(
@@ -451,12 +453,14 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event) {
 							copyUserToClipboard(item->site());
 					}
 						break;
+#ifndef DISABLE_FILL_FORM_SHORTCUTS
 					case ShortcutAction::FillForm:
 						fillForm();
 						break;
 					case ShortcutAction::FillFormPasswordOnly:
 						fillForm(true);
 						break;
+#endif
 					case ShortcutAction::SelectFilter:
 						m_ui->txtFilter->selectAll();
 						m_ui->txtFilter->setFocus();
@@ -484,6 +488,8 @@ bool MainWindow::eventFilter(QObject* obj, QEvent* event) {
 	}
 	return false;
 }
+
+#ifndef DISABLE_FILL_FORM_SHORTCUTS
 void MainWindow::fillForm(bool password_only) {
 	TableItem* item = getSelectedItem();
 	if (item) {
@@ -514,6 +520,7 @@ void MainWindow::fillForm(bool password_only) {
 		//the user probably already released them
 	}
 }
+#endif
 
 void MainWindow::openSelectedUrl() {
 	TableItem* item = getSelectedItem();
@@ -988,10 +995,12 @@ QString MainWindow::description(ShortcutAction action) {
 		return tr("Copy password of selected item to clipboard");
 	case ShortcutAction::CopyUserToClipboard:
 		return tr("Copy login/user name of selected item to clipboard");
+#ifndef DISABLE_FILL_FORM_SHORTCUTS
 	case ShortcutAction::FillForm:
 		return tr("Auto fill form: select next window and fill in user name (if set) and password");
 	case ShortcutAction::FillFormPasswordOnly:
 		return tr("Auto fill form (password only)");
+#endif
 	case ShortcutAction::SelectFilter:
 		return tr("Focus the filter text");
 	case ShortcutAction::PreviousItem:


### PR DESCRIPTION
Fill form shortcuts are the only thing that depends on `class Keypress`, which on Linux is dependent on X11. When the program is running in a Wayland session, then those shortcuts do not work, i.e. they are useless, but still a X11 client connection is created. 

This PR makes all code related to those short cuts optional and the user can disable them with a build configuration option. I.e. she can create an executable that will be a pure Wayland client in a Wayland session.

Fixes #32