### PR TITLE
flatpak: re-use configuration from users home

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.ui]
+indent_size = 1
+
+[*.{yml,appdata.xml}]
+indent_size = 2

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,0 +1,48 @@
+---
+name: build-flatpak
+
+on:
+   workflow_call:
+
+jobs:
+  build-linux:
+    name: Build Flatpak
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        flatpak: [yes]
+      fail-fast: false
+
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-23.08
+      options: --privileged
+
+    steps:
+      - name: Install additional packages
+        run: >
+          dnf install --setopt=install_weak_deps=False -y
+          nodejs
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        # NOTE: this git commit adds support for "upload-artifact: false"
+        # @TODO - replace with tag once included in a release
+        uses: flatpak/flatpak-github-actions/flatpak-builder@b8be6bc0ede43cb3a2cc55895654312b14f84a0d
+        with:
+          bundle: io.github.bkueng.qMasterPassword
+          manifest-path: ./data/flatpak/io.github.bkueng.qMasterPassword.yml
+          cache-key: flatpak-builder-${{ github.sha }}
+          upload-artifact: false
+          verbose: true
+
+      - name: Upload Flatpak
+        uses: actions/upload-artifact@v4
+        with:
+          name: flatpak
+          path: io.github.bkueng.qMasterPassword
+        # skip step when running under act-cli
+        if: |
+          env.ACT != 'true'

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           bundle: io.github.bkueng.qMasterPassword
           manifest-path: ./data/flatpak/io.github.bkueng.qMasterPassword.yml
-          cache-key: flatpak-builder-${{ github.sha }}
+          # NOTE: this is not an official build hence nothing should be cached
+          cache: false
+          #cache-key: flatpak-builder-${{ github.sha }}
           upload-artifact: false
           verbose: true
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -17,6 +17,7 @@ jobs:
           - debian:testing
           - fedora:38
           - fedora:39
+          - fedora:40
           - fedora:rawhide
           - ubuntu:latest
           - ubuntu:rolling
@@ -31,6 +32,8 @@ jobs:
           - container: fedora:38
             qt:        6
             appimage:  true
+          - container: fedora:40
+            no_x11:    true
           - container: fedora:rawhide
             no_x11:    true
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -186,7 +186,7 @@ jobs:
           matrix.appimage
 
       - name: Upload AppImage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: appimage-qt${{ matrix.qt }}
           path: ${{ runner.temp }}/linuxdeploy/qMasterPassword-x86_64.AppImage

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: true
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
         with:
           msbuild-architecture: x64
 
@@ -66,7 +66,7 @@ jobs:
           cmake --build ${{ runner.temp }}/build --config Release --target makensis
 
       - name: Upload installer package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-installer
           path: ${{ runner.temp }}/nsis/qMasterPassword.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
   matrix-precommit:
     uses: ./.github/workflows/pre-commit.yml
 
+  matrix-flatpak:
+    uses: ./.github/workflows/build-flatpak.yml
+
   matrix-linux:
     uses: ./.github/workflows/build-linux.yml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
     - cron:  '16 3 10 * *'
 
 jobs:
+  matrix-precommit:
+    uses: ./.github/workflows/pre-commit.yml
+
   matrix-linux:
     uses: ./.github/workflows/build-linux.yml
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v3.0.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,13 +1,17 @@
 name: pre-commit
 
 on:
-  pull_request:
-  push:
-    branches: [main]
+  workflow_call:
 
 jobs:
   pre-commit:
+    name: Run pre-commit checks
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        pre-commit: [yes]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 
 /windows_build
 
+# flatpak bundle copied out from act-cli container for testing
+# flatpak --user install --bundle ./io.github.bkueng.qMasterPassword
+/io.github.bkueng.qMasterPassword
+
 *.log
 
 /.cproject

--- a/data/flatpak/io.github.bkueng.qMasterPassword.yml
+++ b/data/flatpak/io.github.bkueng.qMasterPassword.yml
@@ -1,0 +1,34 @@
+id: io.github.bkueng.qMasterPassword
+runtime: org.kde.Platform
+runtime-version: '5.15-23.08'
+sdk: org.kde.Sdk
+command: qMasterPassword
+rename-icon: qmasterpassword
+rename-desktop-file: qMasterPassword.desktop
+rename-appdata-file: qMasterPassword.appdata.xml
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --talk-name=org.kde.StatusNotifierWatcher
+modules:
+  - name: libscrypt
+    buildsystem: autotools
+    no-autogen: true
+    make-install-args:
+      - PREFIX=/app
+    sources:
+      - type: archive
+        url: https://github.com/technion/libscrypt/archive/v1.22.tar.gz
+        sha256: a2d30ea16e6d288772791de68be56153965fe4fd4bcd787777618b8048708936
+  - name: qMasterPassword
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DDISABLE_FILL_FORM_SHORTCUTS=ON
+    post-install:
+      - install -Dm644 /app/share/pixmaps/qmasterpassword.png -t /app/share/icons/hicolor/512x512/apps
+    sources:
+      - type: dir
+        path: ../../

--- a/data/flatpak/io.github.bkueng.qMasterPassword.yml
+++ b/data/flatpak/io.github.bkueng.qMasterPassword.yml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=wayland
   - --device=dri
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --filesystem=xdg-config/qMasterPassword:create
 modules:
   - name: libscrypt
     buildsystem: autotools


### PR DESCRIPTION
Add access rights to `${XDG_CONFIG_HOME}/qMasterPassword` to the flatpak application. This allows users to easily switch from a system package to the flatpak application.
