### PR TITLE
flatpak: add deploy step for Flathub

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -2,7 +2,11 @@
 name: build-flatpak
 
 on:
-   workflow_call:
+  workflow_call:
+
+  push:
+    branches:
+      - flathub-release
 
 jobs:
   build-linux:
@@ -48,3 +52,14 @@ jobs:
         # skip step when running under act-cli
         if: |
           env.ACT != 'true'
+
+      - name: Deploy release to Flathub
+        uses: flatpak/flatpak-github-actions/flat-manager@v4
+        with:
+          repository: flathub
+          flat-manager-url: https://flathub.org
+          token: ${{ secrets.FLATHUB_TOKEN }}
+          verbose: true
+        # only execute step when pushing to "flathub-release" branch
+        if: |
+          github.ref == 'refs/heads/flathub-release'

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 # flatpak bundle copied out from act-cli container for testing
 # flatpak --user install --bundle ./io.github.bkueng.qMasterPassword
 /io.github.bkueng.qMasterPassword
+/.event.json
+/.secrets
 
 *.log
 


### PR DESCRIPTION
When commits are pushed to branch "flathub-release" an additional step will be executed to deploy the Flatpak build to Flathub.

- requires secret FLATHUB_TOKEN to be added to GitHub configuration
- add act-cli files needed for "push" event testing to .gitignore