### PR TITLE
identicon: fix build with C++20

### DIFF
--- a/include/identicon.h
+++ b/include/identicon.h
@@ -51,21 +51,10 @@ class Identicon {
         return sizeof(array) / sizeof(array[0]);
     }
 
-    static constexpr const char* left_arm[] = {u8"\u2554", u8"\u255a", u8"\u2570", u8"\u2550"};
-    static constexpr const char* right_arm[] = {u8"\u2557", u8"\u255d", u8"\u256f", u8"\u2550"};
-    static constexpr const char* body[] = {u8"\u2588", u8"\u2591", u8"\u2592",
-                                           u8"\u2593", u8"\u263a", u8"\u263b"};
-    static constexpr const char* accessory[] = {
-        u8"\u25c8", u8"\u25ce", u8"\u25d0", u8"\u25d1", u8"\u25d2", u8"\u25d3", u8"\u2600",
-        u8"\u2601", u8"\u2602", u8"\u2603", u8"\u2604", u8"\u2605", u8"\u2606", u8"\u260e",
-        u8"\u260f", u8"\u2388", u8"\u2302", u8"\u2618", u8"\u2622", u8"\u2623", u8"\u2615",
-        u8"\u231a", u8"\u231b", u8"\u23f0", u8"\u26a1", u8"\u26c4", u8"\u26c5", u8"\u2614",
-        u8"\u2654", u8"\u2655", u8"\u2656", u8"\u2657", u8"\u2658", u8"\u2659", u8"\u265a",
-        u8"\u265b", u8"\u265c", u8"\u265d", u8"\u265e", u8"\u265f", u8"\u2668", u8"\u2669",
-        u8"\u266a", u8"\u266b", u8"\u2690", u8"\u2691", u8"\u2694", u8"\u2696", u8"\u2699",
-        u8"\u26a0", u8"\u2318", u8"\u23ce", u8"\u2704", u8"\u2706", u8"\u2708", u8"\u2709",
-        u8"\u270c"};
-
+    static const char* const left_arm[];
+    static const char* const right_arm[];
+    static const char* const body[];
+    static const char* const accessory[];
     static const QColor colors_dark[];
     static const QColor colors_light[];
 };

--- a/src/identicon.cpp
+++ b/src/identicon.cpp
@@ -17,10 +17,54 @@
 #include "crypto.h"
 #include "crypto_functions.h"
 
-constexpr const char* Identicon::left_arm[];
-constexpr const char* Identicon::right_arm[];
-constexpr const char* Identicon::body[];
-constexpr const char* Identicon::accessory[];
+const char* const Identicon::left_arm[] = {
+    reinterpret_cast<const char*>(u8"\u2554"),
+    reinterpret_cast<const char*>(u8"\u255a"),
+    reinterpret_cast<const char*>(u8"\u2570"),
+    reinterpret_cast<const char*>(u8"\u2550"),
+};
+const char* const Identicon::right_arm[] = {
+    reinterpret_cast<const char*>(u8"\u2557"),
+    reinterpret_cast<const char*>(u8"\u255d"),
+    reinterpret_cast<const char*>(u8"\u256f"),
+    reinterpret_cast<const char*>(u8"\u2550"),
+};
+const char* const Identicon::body[] = {
+    reinterpret_cast<const char*>(u8"\u2588"), reinterpret_cast<const char*>(u8"\u2591"),
+    reinterpret_cast<const char*>(u8"\u2592"), reinterpret_cast<const char*>(u8"\u2593"),
+    reinterpret_cast<const char*>(u8"\u263a"), reinterpret_cast<const char*>(u8"\u263b"),
+};
+const char* const Identicon::accessory[] = {
+    reinterpret_cast<const char*>(u8"\u25c8"), reinterpret_cast<const char*>(u8"\u25ce"),
+    reinterpret_cast<const char*>(u8"\u25d0"), reinterpret_cast<const char*>(u8"\u25d1"),
+    reinterpret_cast<const char*>(u8"\u25d2"), reinterpret_cast<const char*>(u8"\u25d3"),
+    reinterpret_cast<const char*>(u8"\u2600"), reinterpret_cast<const char*>(u8"\u2601"),
+    reinterpret_cast<const char*>(u8"\u2602"), reinterpret_cast<const char*>(u8"\u2603"),
+    reinterpret_cast<const char*>(u8"\u2604"), reinterpret_cast<const char*>(u8"\u2605"),
+    reinterpret_cast<const char*>(u8"\u2606"), reinterpret_cast<const char*>(u8"\u260e"),
+    reinterpret_cast<const char*>(u8"\u260f"), reinterpret_cast<const char*>(u8"\u2388"),
+    reinterpret_cast<const char*>(u8"\u2302"), reinterpret_cast<const char*>(u8"\u2618"),
+    reinterpret_cast<const char*>(u8"\u2622"), reinterpret_cast<const char*>(u8"\u2623"),
+    reinterpret_cast<const char*>(u8"\u2615"), reinterpret_cast<const char*>(u8"\u231a"),
+    reinterpret_cast<const char*>(u8"\u231b"), reinterpret_cast<const char*>(u8"\u23f0"),
+    reinterpret_cast<const char*>(u8"\u26a1"), reinterpret_cast<const char*>(u8"\u26c4"),
+    reinterpret_cast<const char*>(u8"\u26c5"), reinterpret_cast<const char*>(u8"\u2614"),
+    reinterpret_cast<const char*>(u8"\u2654"), reinterpret_cast<const char*>(u8"\u2655"),
+    reinterpret_cast<const char*>(u8"\u2656"), reinterpret_cast<const char*>(u8"\u2657"),
+    reinterpret_cast<const char*>(u8"\u2658"), reinterpret_cast<const char*>(u8"\u2659"),
+    reinterpret_cast<const char*>(u8"\u265a"), reinterpret_cast<const char*>(u8"\u265b"),
+    reinterpret_cast<const char*>(u8"\u265c"), reinterpret_cast<const char*>(u8"\u265d"),
+    reinterpret_cast<const char*>(u8"\u265e"), reinterpret_cast<const char*>(u8"\u265f"),
+    reinterpret_cast<const char*>(u8"\u2668"), reinterpret_cast<const char*>(u8"\u2669"),
+    reinterpret_cast<const char*>(u8"\u266a"), reinterpret_cast<const char*>(u8"\u266b"),
+    reinterpret_cast<const char*>(u8"\u2690"), reinterpret_cast<const char*>(u8"\u2691"),
+    reinterpret_cast<const char*>(u8"\u2694"), reinterpret_cast<const char*>(u8"\u2696"),
+    reinterpret_cast<const char*>(u8"\u2699"), reinterpret_cast<const char*>(u8"\u26a0"),
+    reinterpret_cast<const char*>(u8"\u2318"), reinterpret_cast<const char*>(u8"\u23ce"),
+    reinterpret_cast<const char*>(u8"\u2704"), reinterpret_cast<const char*>(u8"\u2706"),
+    reinterpret_cast<const char*>(u8"\u2708"), reinterpret_cast<const char*>(u8"\u2709"),
+    reinterpret_cast<const char*>(u8"\u270c"),
+};
 
 const QColor Identicon::colors_dark[] = {QColor("#dc322f"), QColor("#859900"), QColor("#b58900"),
                                          QColor("#268bd2"), QColor("#d33682"), QColor("#2aa198"),


### PR DESCRIPTION
C++20 changed the type uf u8"str" to char8_t, which can't be assigned to a char pointer without casting.

- replace "constexpr" with "const" array, because reinterpret_cast is per C++ standard not a constant expression
- move array initialization from the class declaration to the class implementation, just like the two color arrays
- wrap u8 strings in "reinterpret_cast< const char* >()" to make a C++20 compiler happy